### PR TITLE
fix-bad-env-client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Client
-PUBLIC_NEXT_API_URL=http://localhost:8080
+NEXT_PUBLIC_API_URL=http://localhost:8080
 
 # Server
 JWT_SECRET=your-super-secret-jwt-key


### PR DESCRIPTION
Hello

Error in docker compose up -d

```
❯ docker compose up -d 
WARN[0000] The "NEXT_PUBLIC_API_URL" variable is not set. Defaulting to a blank string.
``` 

The env client NEXT_PUBLIC_API_URL is not the same in the env and docker-compose file

docker-compose.yml: NEXT_PUBLIC_API_URL
.env: PUBLIC_NEXT_API_URL



