### PR TITLE
remove version from docker compose file and add yml good practice

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-version: '3.8'
-
+---
 services:
   api:
     build:
@@ -29,3 +28,4 @@ services:
 volumes:
   api_data:
   backup_data:
+...


### PR DESCRIPTION
i have remove the warning of docker compose

```
 130 ❯ docker compose up -d
WARN[0000] /tmp/velld/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

and

check with 

```
❯ yamllint docker-compose.yml && echo "OK"
OK
```