### PR TITLE
fix: comma that is causing an issue with the communication with the api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL},
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
       ALLOW_REGISTER: ${ALLOW_REGISTER}
     depends_on:
       - api


### PR DESCRIPTION
This PR solves an issue where requests are made with a comma in the request url. For example when you try to log in it tries to make a request to `http://localhost:8080,/api/auth/login`, and because of this the request fails.