### PR TITLE
fix: separate data directory from migrations to prevent volume mount issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,11 @@
 NEXT_PUBLIC_API_URL=http://localhost:8080
 
 # Server
-JWT_SECRET=your-super-secret-jwt-key
-ENCRYPTION_KEY=your-32-byte-encryption-key
+JWT_SECRET=your-super-secret-jwt-key-here-use-openssl-rand-hex-32
+ENCRYPTION_KEY=your-64-char-hex-key-here-use-openssl-rand-hex-32
+
+# Database (optional - defaults to /app/data/velld.db)
+# DB_PATH=/app/data/velld.db
 
 # Auth Credentials
 ADMIN_USERNAME_CREDENTIAL=your-super-username-admin

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ A self-hosted database backup management tool. Schedule automated backups, monit
 - Built-in backup comparison and diff viewer
 - Database restore functionality
 - Email notifications for failed backups
-- Responsive web interface
 
 ## Getting Started
 
@@ -24,11 +23,32 @@ Create a `.env` file:
 
 ```bash
 NEXT_PUBLIC_API_URL=http://localhost:8080
+
+# Generate secure keys (IMPORTANT!)
 JWT_SECRET=$(openssl rand -hex 32)
 ENCRYPTION_KEY=$(openssl rand -hex 32)
+
+# Admin credentials
 ADMIN_USERNAME_CREDENTIAL=admin
 ADMIN_PASSWORD_CREDENTIAL=changeme
+
+# Registration (set to false in production)
+ALLOW_REGISTER=true
 ```
+
+> **Important:** The `ENCRYPTION_KEY` must be a **64-character hex string**. Don't use shell commands like `$(openssl rand -hex 32)` directly in `.env` files - they won't execute. Instead, run the command in your terminal and paste the output.
+
+**Generate keys properly:**
+
+```bash
+# Generate and display keys
+echo "JWT_SECRET=$(openssl rand -hex 32)"
+echo "ENCRYPTION_KEY=$(openssl rand -hex 32)"
+
+# Copy the output to your .env file
+```
+
+Start the containers:
 
 ```bash
 docker compose up -d

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -25,7 +25,7 @@ go.work.sum
 backups/*
 
 # Dataase files
-internal/database/*.db
+data/*
 
 # Tmp File
 tmp

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -6,7 +6,7 @@ services:
     env_file:
       - .env
     volumes:
-      - api_data:/app/internal/database
+      - api_data:/app/data
       - backup_data:/app/backups
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     env_file:
       - .env
     volumes:
-      - api_data:/app/internal/database
+      - api_data:/app/data
       - backup_data:/app/backups
     restart: unless-stopped
 

--- a/docs/web/content/docs/installation.mdx
+++ b/docs/web/content/docs/installation.mdx
@@ -34,8 +34,8 @@ docker pull ghcr.io/dendianugerah/velld/web:latest
 # Create .env file
 cat > .env << EOF
 NEXT_PUBLIC_API_URL=http://localhost:8080
-JWT_SECRET=your-super-secret-jwt-key
-ENCRYPTION_KEY=your-32-byte-encryption-key / $(openssl rand -hex 32)
+JWT_SECRET=$(openssl rand -hex 32)
+ENCRYPTION_KEY=$(openssl rand -hex 32)
 ADMIN_USERNAME_CREDENTIAL=admin
 ADMIN_PASSWORD_CREDENTIAL=changeme
 ALLOW_REGISTER=true
@@ -46,7 +46,7 @@ docker run -d \
   --name velld-api \
   -p 8080:8080 \
   --env-file .env \
-  -v velld-data:/app/internal/database \
+  -v velld-data:/app/data \
   -v velld-backups:/app/backups \
   ghcr.io/dendianugerah/velld/api:latest
 
@@ -58,6 +58,10 @@ docker run -d \
   -e ALLOW_REGISTER=true \
   ghcr.io/dendianugerah/velld/web:latest
 ```
+
+<Callout type="warning">
+  **Important:** The data directory has changed from `/app/internal/database` to `/app/data`. If you're upgrading from an older version, see the [migration guide](#migrating-from-older-versions).
+</Callout>
 
 Open [http://localhost:3000](http://localhost:3000) in your browser.
 
@@ -145,7 +149,7 @@ Choose only the database client you need to keep your installation lightweight:
         env_file:
           - .env
         volumes:
-          - api_data:/app/internal/database
+          - api_data:/app/data
           - backup_data:/app/backups
         restart: unless-stopped
 
@@ -229,7 +233,7 @@ Choose only the database client you need to keep your installation lightweight:
         env_file:
           - .env
         volumes:
-          - api_data:/app/internal/database
+          - api_data:/app/data
           - backup_data:/app/backups
         restart: unless-stopped
 
@@ -313,7 +317,7 @@ Choose only the database client you need to keep your installation lightweight:
         env_file:
           - .env
         volumes:
-          - api_data:/app/internal/database
+          - api_data:/app/data
           - backup_data:/app/backups
         restart: unless-stopped
 
@@ -351,32 +355,58 @@ Choose only the database client you need to keep your installation lightweight:
 
 ## Environment Configuration
 
-Create a `.env` file in the project root or copy from `.env.example`:
+Create a `.env` file in the project root:
 
 ```bash
 cp .env.example .env
 ```
 
-### Environment Variables
+### Required Variables
 
-| Variable | Description | Required | Default Behavior |
-|----------|-------------|----------|------------------|
-| `NEXT_PUBLIC_API_URL` | Base URL for the API server | Yes | `http://localhost:8080` |
-| `JWT_SECRET` | Secret key for JWT token signing | Optional | Auto-generated if missing |
-| `ENCRYPTION_KEY` | Key for encrypting sensitive data (database credentials) | Optional | Auto-generated if missing |
-| `ALLOW_REGISTER` | Enable/disable user registration | Optional | `true` |
-| `ADMIN_USERNAME_CREDENTIAL` | Admin username for login | Only if `ALLOW_REGISTER=false` | - |
-| `ADMIN_PASSWORD_CREDENTIAL` | Admin password for login | Only if `ALLOW_REGISTER=false` | - |
-| `SMTP_HOST` | SMTP server hostname for email notifications | Optional | - |
-| `SMTP_PORT` | SMTP server port | Optional | `587` |
-| `SMTP_USER` | Email address for sending notifications | Optional | - |
-| `SMTP_PASSWORD` | SMTP password or app-specific password | Optional | - |
-| `SMTP_FROM` | "From" address in notification emails | Optional | - |
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `NEXT_PUBLIC_API_URL` | API server URL (must be accessible from browser) | `http://localhost:8080` |
+| `JWT_SECRET` | JWT signing key - generate with `openssl rand -hex 32` | 64 hex characters |
+| `ENCRYPTION_KEY` | Database credential encryption key - generate with `openssl rand -hex 32` | 64 hex characters |
+
+<Callout type="error">
+  **Production:** Always set `JWT_SECRET` and `ENCRYPTION_KEY` manually. While they auto-generate if missing, changing keys will log out users and break database connections.
+  
+  ```bash
+  # Generate secure keys
+  openssl rand -hex 32  # Run twice, once for each
+  ```
+</Callout>
+
+### Authentication
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ALLOW_REGISTER` | Enable public registration | `true` |
+| `ADMIN_USERNAME_CREDENTIAL` | Admin username (required if `ALLOW_REGISTER=false`) | - |
+| `ADMIN_PASSWORD_CREDENTIAL` | Admin password (required if `ALLOW_REGISTER=false`) | - |
+
+### Optional: Email Notifications
+
+Configure SMTP to get notified when backups fail:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SMTP_HOST` | SMTP server hostname | - |
+| `SMTP_PORT` | SMTP port | `587` |
+| `SMTP_USER` | SMTP username/email | - |
+| `SMTP_PASSWORD` | SMTP password (use [App Password](https://support.google.com/accounts/answer/185833) for Gmail) | - |
+| `SMTP_FROM` | From address | - |
+
+### Advanced
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DB_PATH` | Path to Velld's SQLite database | `/app/data/velld.db` |
+| `PORT` | API server port | `8080` |
 
 <Callout type="info">
-  **`ALLOW_REGISTER` Behavior:**
-  - `true` (default) - Anyone can register via `/register`. Admin credentials are not required.
-  - `false` - Registration disabled. `ADMIN_USERNAME_CREDENTIAL` and `ADMIN_PASSWORD_CREDENTIAL` are required for login.
+  **Data Persistence:** Ensure `/app/data` is mounted as a volume to persist your database.
 </Callout>
 
 ---

--- a/docs/web/content/docs/troubleshooting.mdx
+++ b/docs/web/content/docs/troubleshooting.mdx
@@ -317,13 +317,13 @@ See [Installation Guide](/docs/installation) for details.
 
 2. **Check database size:**
    ```bash
-   docker exec velld-api-1 ls -lh /app/internal/database/
+   docker exec velld-api-1 ls -lh /app/data/
    ```
 
 3. **Optimize SQLite database:**
    ```bash
    docker exec velld-api-1 sh
-   sqlite3 /app/internal/database/velld.db "VACUUM;"
+   sqlite3 /app/data/velld.db "VACUUM;"
    ```
 
 ### Backups are Slow


### PR DESCRIPTION
## Problem

Users with bind mounts (local folders) were getting "migrations directory does not exist" errors on startup because mounting a volume to `/app/internal/database` overwrites the migrations folder.

**Example that broke:**
```yaml
volumes:
  - ./data:/app/internal/database  # Overwrites migrations/