### PR TITLE
Fixed S3 Secret Key not being used

### DIFF
--- a/apps/api/internal/backup/backup_service.go
+++ b/apps/api/internal/backup/backup_service.go
@@ -331,7 +331,7 @@ func (s *BackupService) GetBackupStats(userID uuid.UUID) (*BackupStats, error) {
 }
 
 func (s *BackupService) uploadToS3IfEnabled(backup *Backup, userID uuid.UUID) error {
-	userSettings, err := s.settingsService.GetUserSettings(userID)
+	userSettings, err := s.settingsService.GetUserSettingsInternal(userID)
 	if err != nil {
 		return fmt.Errorf("failed to get user settings: %w", err)
 	}


### PR DESCRIPTION
This fixes #55 

## What was changed:

- userSettings, err := s.settingsService.GetUserSettings(userID)
+ userSettings, err := s.settingsService.GetUserSettingsInternal(userID)

## Why this fixes the issue:

1. GetUserSettings() - Strips sensitive data (passwords, secret keys) before returning. This is used for API responses to the frontend.
2. GetUserSettingsInternal() - Returns the complete settings including encrypted sensitive data. This is designed for internal use within the backend services.

The backup service needs the actual S3 secret key to decrypt it and upload backups to S3, so it must use the internal method.

## Testing the fix:

After rebuilding the API server, you should now be able to:

1. Save your S3 secret key in the settings (which was working all along)
2. Create a backup with S3 upload enabled
3. The backup will successfully upload to S3 without the "S3 secret key not configured" warning

The secret key was being saved correctly all along - the issue was just in retrieving it during the backup upload process!