### PR TITLE
fix: MySQL restore command to support SSL options

### DIFF
--- a/apps/api/internal/backup/backup_restore.go
+++ b/apps/api/internal/backup/backup_restore.go
@@ -200,13 +200,22 @@ func (s *BackupService) createMySQLRestoreCmd(conn *connection.StoredConnection,
 
 	binPath := filepath.Join(binaryPath, common.GetPlatformExecutableName(restoreTools[conn.Type]))
 
-	cmd := exec.Command(binPath,
+	args := []string{
 		"-h", conn.Host,
 		"-P", fmt.Sprintf("%d", conn.Port),
 		"-u", conn.Username,
 		fmt.Sprintf("-p%s", conn.Password),
-		conn.DatabaseName,
-	)
+	}
+
+	if !conn.SSL {
+		args = append(args, "--skip-ssl")
+	} else {
+		args = append(args, "--ssl-mode=REQUIRED")
+	}
+
+	args = append(args, conn.DatabaseName)
+
+	cmd := exec.Command(binPath, args...)
 
 	file, err := os.Open(backupPath)
 	if err != nil {


### PR DESCRIPTION
[MySQL restore testing function is normal](fix: MySQL restore command to support SSL options)
<img width="2560" height="1273" alt="image" src="https://github.com/user-attachments/assets/56948472-c7d9-4362-8fb0-7063daaf2430" />
<img width="2560" height="1273" alt="image" src="https://github.com/user-attachments/assets/3a295c72-6472-4278-8a9c-9c72aa6e4e18" />
<img width="2560" height="1273" alt="image" src="https://github.com/user-attachments/assets/b8fb1dbd-654a-4576-b93f-f3fde2a8d460" />
<img width="1956" height="1273" alt="image" src="https://github.com/user-attachments/assets/382b8ccf-911d-4e40-981a-77a849218ad4" />
<img width="2560" height="1273" alt="image" src="https://github.com/user-attachments/assets/3b3a6b44-8b24-4366-a7da-547dbed6e149" />
