### PR TITLE
Fix: Prevent null return in database discovery API

### DIFF
--- a/apps/api/internal/connection/connection_config.go
+++ b/apps/api/internal/connection/connection_config.go
@@ -335,6 +335,11 @@ func (cm *ConnectionManager) DiscoverDatabases(config ConnectionConfig) ([]strin
 		return nil, fmt.Errorf("unsupported database type for discovery: %s", config.Type)
 	}
 
+	// Ensure we never return nil, always return an empty array
+	if databases == nil {
+		databases = []string{}
+	}
+
 	return databases, err
 }
 
@@ -353,7 +358,7 @@ func (cm *ConnectionManager) discoverPostgresDatabases(db *sql.DB) ([]string, er
 	}
 	defer rows.Close()
 
-	var databases []string
+	databases := []string{}
 	for rows.Next() {
 		var dbName string
 		if err := rows.Scan(&dbName); err != nil {
@@ -379,7 +384,7 @@ func (cm *ConnectionManager) discoverMySQLDatabases(db *sql.DB) ([]string, error
 	}
 	defer rows.Close()
 
-	var databases []string
+	databases := []string{}
 	for rows.Next() {
 		var dbName string
 		if err := rows.Scan(&dbName); err != nil {
@@ -400,7 +405,7 @@ func (cm *ConnectionManager) discoverMongoDBDatabases(client *mongo.Client) ([]s
 	}
 
 	// Filter out system databases
-	var filtered []string
+	filtered := []string{}
 	for _, db := range databases {
 		if db != "admin" && db != "local" && db != "config" {
 			filtered = append(filtered, db)


### PR DESCRIPTION
### Problem

The database discovery modal was crashing in the browser with Uncaught TypeError: Cannot read
properties of null (reading 'filter') when opening for certain connections.

### Root Cause

The Go backend was returning null instead of an empty array [] when no databases were found during
discovery. In Go, uninitialized slices (var databases []string) are nil, which serializes to null in
JSON responses, causing JavaScript to crash when calling .filter() on the result.

### Solution

• Initialize all database slices as empty arrays ([]string{}) instead of nil slices in
discoverPostgresDatabases, discoverMySQLDatabases, and discoverMongoDBDatabases
• Added safety check in DiscoverDatabases to ensure nil is never returned

### Impact

• Fixes browser crash when discovering databases
• Ensures consistent API responses (empty arrays instead of null)
• No frontend changes required - the TypeScript types already expected string[]